### PR TITLE
Fix a bug that happens when you call add multiple times inside a loop.  

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ Insights.prototype.stop = function(){
 Insights.prototype.send = function(){
   var that = this;
   if (that.config.enabled && that.data.length > 0){
+    var bodyData = that.data;
+    that.data = [];
     try {
       request({
         method: 'POST',
@@ -60,9 +62,8 @@ Insights.prototype.send = function(){
           "X-Insert-Key": this.config.insertKey
         },
         url: (Insights.collectorBaseURL + that.urlPathPrefix + "events"),
-        body: that.data
+        body: bodyData
       }, function(err, res, body){
-        that.data.length = 0;
         if (err){
           logger.error('Error sending to insights', err);
         }
@@ -72,7 +73,6 @@ Insights.prototype.send = function(){
       });
     }
     catch(x){
-      that.data.length = 0;
       logger.error(x);
     }
   }
@@ -114,7 +114,7 @@ Insights.prototype.add = function(data, eventType){
     logger.log('Insights data', insight);
     that.data.push(insight);
 
-    if (that.data.length > that.config.maxPending){
+    if (that.data.length >= that.config.maxPending){
       that.stop();
       that.send();
     }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "license": "ISC",
   "dependencies": {
     "lodash": "^3.6.0",
-    "request": "^2.54.0"
+    "request": "^2.54.0",
+    "rewire": "^2.3.1"
   },
   "devDependencies": {
     "chai": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-insights",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Submit and query New Relic Insights data",
   "main": "index.js",
   "scripts": {
@@ -21,8 +21,7 @@
   "license": "ISC",
   "dependencies": {
     "lodash": "^3.6.0",
-    "request": "^2.54.0",
-    "rewire": "^2.3.1"
+    "request": "^2.54.0"
   },
   "devDependencies": {
     "chai": "^2.2.0",
@@ -34,6 +33,7 @@
     "load-grunt-tasks": "^3.1.0",
     "mocha": "^2.2.1",
     "nock": "^1.4.0",
-    "time-grunt": "^1.1.0"
+    "time-grunt": "^1.1.0",
+    "rewire": "^2.3.1"
   }
 }


### PR DESCRIPTION
Asynchronous request() was being called more times than it should have, and duplicated data was being sent to Insights.