### PR TITLE
no longer require global grunt for test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
     "chai": "^2.2.0",
     "grunt": "^0.4.5",
     "grunt-cafe-mocha": "^0.1.13",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-env": "^0.4.4",
     "grunt-exec": "^0.4.6",
     "load-grunt-tasks": "^3.1.0",
     "mocha": "^2.2.1",
     "nock": "^1.4.0",
-    "time-grunt": "^1.1.0",
-    "rewire": "^2.3.1"
+    "rewire": "^2.3.1",
+    "time-grunt": "^1.1.0"
   }
 }


### PR DESCRIPTION
`npm test` is an alias for `npm run test`. `npm run` adds `./node_modules/.bin` to the path so you don't have to globally install commands. This is especially helpful for those of us who change node versions many times a day and would have to globally install in each of those versions.