### PR TITLE
increase default limit to api limit of 1000

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function Insights(config){
     insertKey: '',
     queryKey: '',
     timerInterval: 10000,
-    maxPending: 100,
+    maxPending: 1000,
     defaultEventType: 'data',
     baseURL: null,
     url: null


### PR DESCRIPTION
This fixes #3. It is explained in that issue but I'll also put it here. The backend deals in larger batches better than many smaller batches. Because 1000 is the API limit the library should also use that limit.