### PR TITLE
track the add time of events

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ The defaultEventType **defaults** to the string 'data'. Awesome!
 insights.add({ ... }, 'my-custom-event-type');
 ```
 
+### timestamps
+By default Insights will use the time data is sent to the server as the timestamp. Because this library buffers data for up to 10s, we will automatically add a timestamp when you call `insights.add()`.
+
+If you provide your own timestamp (keeping in mind the date has to be within a day of the Insight server's time), the library will not overwrite the user provided one.
+
 ### querying data
 To retrieve data from Insights you will need to use your [query key](https://docs.newrelic.com/docs/insights/new-relic-insights/adding-querying-data/querying-your-data-remotely#register) to execute NRQL queries.
 

--- a/index.js
+++ b/index.js
@@ -111,6 +111,10 @@ Insights.prototype.add = function(data, eventType){
       "eventType": eventType || that.config.defaultEventType
     });
 
+    if (insight.timestamp === undefined) {
+      insight.timestamp = Date.now();
+    }
+
     logger.log('Insights data', insight);
     that.data.push(insight);
 


### PR DESCRIPTION
This fixes #4. It adds the timestamp to the object when it is added if the timestamp field was not already set. It uses `Date.now()` which provides the time in ms since epoch.

I had to update a couple tests to account for this variable data. Also I added a test to make sure it doesn't stomp the timestamp.